### PR TITLE
Fix for black fade on background transitions

### DIFF
--- a/src/animation/fadeeffect.cpp
+++ b/src/animation/fadeeffect.cpp
@@ -18,8 +18,8 @@ void FadeEffect::fade(sf::RenderWindow& window)
     firstFrame.setTextureRect(mFrames[0].mFrame);
     nextFrame .setTextureRect(mFrames[1].mFrame);
 
-    firstFrame.setColor(sf::Color(0, 0, 0, opacityMain));
-    nextFrame.setColor(sf::Color(0, 0, 0, opacityNext));
+    firstFrame.setColor(sf::Color(255, 255, 255, opacityMain));
+    nextFrame.setColor(sf::Color(255, 255, 255, opacityNext));
 
     opacityMain--;
     opacityNext++;


### PR DESCRIPTION
The reason your transition was turning black is that the colour value of a sprite is multiplied with the colour stored in the texture. Setting the colour channels to zero multiplies the colour value by zero resulting in a transparent black which will bleed through a darker colour of whatever you're clearing the window with. See [docs](http://www.sfml-dev.org/tutorials/2.3/graphics-sprite.php#ok-can-i-have-my-sprite-now) for more detail.

This pull request should fix your transition turning black. You also don't need to change the transparency of both sprites. SFML renders your draws in order and therefore I would render the current background at full opacity and then render the new background on top of it and then slowly increase the opacity of the new background until it is at full opacity and then stop rendering the old background entirely.
